### PR TITLE
Fix reentrant deadlock

### DIFF
--- a/include/boost/msm-lite.hpp
+++ b/include/boost/msm-lite.hpp
@@ -1247,7 +1247,7 @@ class sm {
       BOOST_MSM_LITE_NOEXCEPT_IF(is_noexcept) {
     static bool (*dispatch_table[!sizeof...(TStates) ? 1 : sizeof...(TStates)])(
         sm &, const TEvent &, aux::byte &) = {&get_state_mapping_t<TStates, TMappings>::template execute<sm, TEvent>...};
-    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::mutex> guard{mutex_});
+    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::recursive_mutex> guard{mutex_});
     return dispatch_table[current_state_[0]](*this, event, current_state_[0]);
   }
 
@@ -1256,7 +1256,7 @@ class sm {
       BOOST_MSM_LITE_NOEXCEPT_IF(is_noexcept) {
     static bool (*dispatch_table[!sizeof...(TStates) ? 1 : sizeof...(TStates)])(
         sm &, const TEvent &, aux::byte &) = {&get_state_mapping_t<TStates, TMappings>::template execute<sm, TEvent>...};
-    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::mutex> guard{mutex_});
+    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::recursive_mutex> guard{mutex_});
     return dispatch_table[current_state](*this, event, current_state);
   }
 
@@ -1266,7 +1266,7 @@ class sm {
     static bool (*dispatch_table[!sizeof...(TStates) ? 1 : sizeof...(TStates)])(
         sm &, const TEvent &, aux::byte &) = {&get_state_mapping_t<TStates, TMappings>::template execute<sm, TEvent>...};
     auto handled = false;
-    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::mutex> guard{mutex_});
+    BOOST_MSM_LITE_THREAD_SAFE__(std::lock_guard<std::recursive_mutex> guard{mutex_});
     int _[]{0, (handled |= dispatch_table[current_state_[Ns]](*this, event, current_state_[Ns]), 0)...};
     (void)_;
     return handled;
@@ -1409,7 +1409,7 @@ class sm {
   aux::byte current_state_[regions];
 
  private:
-  BOOST_MSM_LITE_THREAD_SAFE__(std::mutex mutex_;)
+  BOOST_MSM_LITE_THREAD_SAFE__(std::recursive_mutex mutex_;)
 };
 template <class TEvent = void>
 struct dispatch_event_impl {


### PR DESCRIPTION
* Switched from `std::mutex` to `std::recursive_mutex` to avoid deadlock when `process_event` is called during another `process_event` call.
* Added a test case showing the issue.  Unfortunately the test case is rather harsh, since without the fix the test executable just hangs forever ;)
* In #61 it was mentioned that eventually the mutex type will be configurable, but for now this solves the immediate problem.