### PR TITLE
Add support for `c_str()` in user defined events and state types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test/ft_unit%.out:
 test/ft_units.out: test/ft_unit1.out test/ft_unit2.out
 	$(CXX) test/ft_units.cpp $(CXXFLAGS) -fno-exceptions $($(COVERAGE)) -I include -I. -include test/test.hpp test/ft_unit1.out test/ft_unit2.out -o test/ft_units.out
 
+test/ft_logging.out:
+	$(CXX) test/ft_logging.cpp $(CXXFLAGS) -fno-exceptions $($(COVERAGE)) -I include -I. -include test/test.hpp -o test/ft_logging.out && $($(MEMCHECK)) test/ft_logging.out
+
 example: $(patsubst %.cpp, %.out, $(shell find example -iname "*.cpp"))
 
 example/errors/%.out:

--- a/test/ft_logging.cpp
+++ b/test/ft_logging.cpp
@@ -1,0 +1,110 @@
+
+#include <vector>
+#include <sstream>
+
+std::vector<std::string> messages_out;
+
+template <class SM, class TEvent>
+void log_process_event(const TEvent& evt) {
+	std::stringstream sstr;
+	sstr << evt.c_str();
+	messages_out.push_back(sstr.str());
+}
+
+
+template <class SM, class TGuard, class TEvent>
+void log_guard(const TGuard&, const TEvent&, bool) {
+}
+
+
+template <class SM, class TAction, class TEvent>
+void log_action(const TAction&, const TEvent&) {
+}
+
+
+template <class SM, class TSrcState, class TDstState>
+void log_state_change(const TSrcState& src, const TDstState& dst) {
+	std::stringstream sstr;
+	sstr << src.c_str() << " -> " << dst.c_str();
+	messages_out.push_back(sstr.str());
+}
+
+
+#define BOOST_MSM_LITE_LOG(T, SM, ...) log_##T<SM>(__VA_ARGS__)
+
+#include <boost/msm-lite.hpp>
+
+namespace msm = boost::msm::lite;
+
+struct e2 {
+	static auto c_str() { return "An Event"; }
+};
+struct s1_label {
+	static auto c_str() { return "A State"; }
+};
+auto s1 = msm::state<s1_label>{};
+
+test logging = [] {
+  messages_out.clear();
+  std::vector<std::string> messages_expected = {
+	  "e1",
+	  "idle -> A State",
+	  "An Event",
+	  "A State -> terminate"
+  };
+  struct c {
+    auto configure() noexcept {
+      using namespace msm;
+      // clang-format off
+      return make_transition_table(
+          *"idle"_s + "e1"_t = s1
+        , s1 + event<e2> = X
+      );
+      // clang-format on
+    }
+  };
+
+
+  msm::sm<c> sm;
+  using namespace msm;
+  expect(sm.process_event("e1"_t));
+  expect(sm.process_event(e2{}));
+  expect(messages_out.size() == messages_expected.size());
+  expect(std::equal(messages_out.begin(), messages_out.end(), messages_expected.begin()));
+};
+
+test logging_entry_exit = [] {
+  messages_out.clear();
+  std::vector<std::string> messages_expected = {
+	  "e1",
+	  "on_exit",
+	  "idle -> A State",
+	  "on_entry",
+	  "An Event",
+	  "on_exit",
+	  "A State -> terminate",
+	  "on_entry"
+  };
+
+  struct c {
+    auto configure() noexcept {
+      using namespace msm;
+      // clang-format off
+      return make_transition_table(
+          *"idle"_s + "e1"_t = s1
+		, s1 + msm::on_entry / [](){}
+		, s1 + msm::on_exit / [](){}
+        , s1 + event<e2> = X
+      );
+      // clang-format on
+    }
+  };
+
+  msm::sm<c> sm;
+  using namespace msm;
+  expect(sm.process_event("e1"_t));
+  expect(sm.process_event(e2{}));
+  expect(messages_out.size() == messages_expected.size());
+  expect(std::equal(messages_out.begin(), messages_out.end(), messages_expected.begin()));
+};
+

--- a/test/ft_logging.cpp
+++ b/test/ft_logging.cpp
@@ -6,9 +6,9 @@ std::vector<std::string> messages_out;
 
 template <class SM, class TEvent>
 void log_process_event(const TEvent& evt) {
-	std::stringstream sstr;
-	sstr << evt.c_str();
-	messages_out.push_back(sstr.str());
+  std::stringstream sstr;
+  sstr << evt.c_str();
+  messages_out.push_back(sstr.str());
 }
 
 
@@ -24,9 +24,9 @@ void log_action(const TAction&, const TEvent&) {
 
 template <class SM, class TSrcState, class TDstState>
 void log_state_change(const TSrcState& src, const TDstState& dst) {
-	std::stringstream sstr;
-	sstr << src.c_str() << " -> " << dst.c_str();
-	messages_out.push_back(sstr.str());
+  std::stringstream sstr;
+  sstr << src.c_str() << " -> " << dst.c_str();
+  messages_out.push_back(sstr.str());
 }
 
 
@@ -37,20 +37,20 @@ void log_state_change(const TSrcState& src, const TDstState& dst) {
 namespace msm = boost::msm::lite;
 
 struct e2 {
-	static auto c_str() { return "An Event"; }
+  static auto c_str() { return "An Event"; }
 };
 struct s1_label {
-	static auto c_str() { return "A State"; }
+  static auto c_str() { return "A State"; }
 };
 auto s1 = msm::state<s1_label>{};
 
 test logging = [] {
   messages_out.clear();
   std::vector<std::string> messages_expected = {
-	  "e1",
-	  "idle -> A State",
-	  "An Event",
-	  "A State -> terminate"
+    "e1",
+    "idle -> A State",
+    "An Event",
+    "A State -> terminate"
   };
   struct c {
     auto configure() noexcept {
@@ -76,14 +76,14 @@ test logging = [] {
 test logging_entry_exit = [] {
   messages_out.clear();
   std::vector<std::string> messages_expected = {
-	  "e1",
-	  "on_exit",
-	  "idle -> A State",
-	  "on_entry",
-	  "An Event",
-	  "on_exit",
-	  "A State -> terminate",
-	  "on_entry"
+    "e1",
+    "on_exit",
+    "idle -> A State",
+    "on_entry",
+    "An Event",
+    "on_exit",
+    "A State -> terminate",
+    "on_entry"
   };
 
   struct c {
@@ -92,8 +92,8 @@ test logging_entry_exit = [] {
       // clang-format off
       return make_transition_table(
           *"idle"_s + "e1"_t = s1
-		, s1 + msm::on_entry / [](){}
-		, s1 + msm::on_exit / [](){}
+        , s1 + msm::on_entry / [](){}
+        , s1 + msm::on_exit / [](){}
         , s1 + event<e2> = X
       );
       // clang-format on


### PR DESCRIPTION
* Currently, `""_t` events have a `c_str` method, and user defined
events can be defined to have a `c_str` method, but internal events do
not have a `c_str` method. This omission means you cannot use `c_str`
when logging events.
* Also, `""_s` states and the special "terminate" state support `c_str`.
But user-defined `c_str` members are not used when logging states -
`__PRETTY_FUNCTION__` is always used.
* So add `c_str` function to `internal_event`s and derivatives, so that
all events can be assumed to have a `c_str` function when logging
(assuming the user defines their custom events with a `c_str` method).
* Also add support for `c_str` function within state types via a
`stringable` concept.
* Added a test case for logging of events, internal events, and states.

The `stringable` concept could maybe (probably) be more elegantly written.  msm-lite is a wonderful learning experience for me in the more advanced uses of template programming - I am by no means a template guru!